### PR TITLE
set default locale for the system

### DIFF
--- a/scripts/custom.sh
+++ b/scripts/custom.sh
@@ -5,9 +5,8 @@ echo "Europe/Paris" > /etc/timezone
 dpkg-reconfigure -f noninteractive tzdata
 
 # Configure locale
-debconf-set-selections <<< 'locales locales/locales_to_be_generated select fr_FR.UTF-8 UTF-8'
-debconf-set-selections <<< 'locales locales/default_environment_locale select fr_FR.UTF-8'
-sed -i 's@# fr_FR.UTF-8@fr_FR.UTF-8@' /etc/locale.gen
+debconf-set-selections <<< 'locales locales/locales_to_be_generated select en_US.UTF-8 UTF-8'
+debconf-set-selections <<< 'locales locales/default_environment_locale select en_US.UTF-8'
 dpkg-reconfigure -f noninteractive locales
-update-locale LANG=fr_FR.UTF-8
-update-locale LC_CTYPE=fr_FR.UTF-8
+update-locale LANG=en_US.UTF-8
+update-locale LC_CTYPE=en_US.UTF-8

--- a/scripts/custom.sh
+++ b/scripts/custom.sh
@@ -3,3 +3,11 @@ apt-get -y install git-core htop vim screen fontconfig curl unzip tree
 # Change timezone
 echo "Europe/Paris" > /etc/timezone
 dpkg-reconfigure -f noninteractive tzdata
+
+# Configure locale
+debconf-set-selections <<< 'locales locales/locales_to_be_generated select fr_FR.UTF-8 UTF-8'
+debconf-set-selections <<< 'locales locales/default_environment_locale select fr_FR.UTF-8'
+sed -i 's@# fr_FR.UTF-8@fr_FR.UTF-8@' /etc/locale.gen
+dpkg-reconfigure -f noninteractive locales
+update-locale LANG=fr_FR.UTF-8
+update-locale LC_CTYPE=fr_FR.UTF-8


### PR DESCRIPTION
The mysql client connects to the database with the charset `latin1` when the locale is not configured.