### PR TITLE
change default xdebug settings

### DIFF
--- a/scripts/xdebug.sh
+++ b/scripts/xdebug.sh
@@ -8,6 +8,6 @@ echo "xdebug.remote_enable = 1" | tee -a /etc/php/7.1/mods-available/xdebug.ini
 # It is better to set the host IP instead of enabling `remote_connect_back` because when debegugging CLI scripts
 # Xdebug can't connect to any IP.
 echo "xdebug.remote_host = 10.0.2.2" | tee -a /etc/php/7.1/mods-available/xdebug.ini
-echo "xdebug.default_enable = 1" | tee -a /etc/php/7.1/mods-available/xdebug.ini
+echo "xdebug.remote_autostart = 1" | tee -a /etc/php/7.1/mods-available/xdebug.ini
 
 service apache2 restart

--- a/scripts/xdebug.sh
+++ b/scripts/xdebug.sh
@@ -3,6 +3,11 @@ apt-get install -y php-xdebug
 echo "xdebug.var_display_max_depth = 16" | tee -a /etc/php/7.1/mods-available/xdebug.ini
 echo "xdebug.cli_color = 2" | tee -a /etc/php/7.1/mods-available/xdebug.ini
 echo "xdebug.remote_enable = 1" | tee -a /etc/php/7.1/mods-available/xdebug.ini
-echo "xdebug.remote_connect_back = 1" | tee -a /etc/php/7.1/mods-available/xdebug.ini
+# With virtualbox 10.0.2.2 is always the host IP
+# > 10.0.2.2    Special alias to your host loopback interface (i.e., 127.0.0.1 on your development machine)
+# It is better to set the host IP instead of enabling `remote_connect_back` because when debegugging CLI scripts
+# Xdebug can't connect to any IP.
+echo "xdebug.remote_host = 10.0.2.2" | tee -a /etc/php/7.1/mods-available/xdebug.ini
+echo "xdebug.default_enable = 1" | tee -a /etc/php/7.1/mods-available/xdebug.ini
 
 service apache2 restart


### PR DESCRIPTION
The use of `remote_host` in vagrant is better than `remote_connect_back` because in a virtualbox VM, the host IP is always 10.0.2.2.
I enabled by default the remote debugging so that there is no need to set up a special env var XDEBUG_CONFIG for CLI or put XDEBUG_SESSION_START in the query of the url