### PR TITLE
Add github.com to known hosts

### DIFF
--- a/scripts/custom.sh
+++ b/scripts/custom.sh
@@ -10,3 +10,7 @@ debconf-set-selections <<< 'locales locales/default_environment_locale select en
 dpkg-reconfigure -f noninteractive locales
 update-locale LANG=en_US.UTF-8
 update-locale LC_CTYPE=en_US.UTF-8
+
+# Setup known hosts
+mkdir -p /home/vagrant/.ssh/
+ssh-keyscan -t rsa -H github.com >> /home/vagrant/.ssh/known_hosts


### PR DESCRIPTION
Actuellement à chaque création de box, je me tape 
> The authenticity of host 'github.com (192.30.253.113)' can't be established.

Je ne suis pas sur que ce soit dans le bon fichier, et je n'ai pas encore testé de build la box moi même, c'est + une suggestion