### PR TITLE
Set correct permissions for /home/vagrant/.config

### DIFF
--- a/scripts/js.sh
+++ b/scripts/js.sh
@@ -2,3 +2,4 @@ curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 apt-get -y install nodejs
 curl -L --insecure https://www.npmjs.org/install.sh | bash
 npm install -g gulp
+chown -R vagrant:vagrant /home/vagrant/.config


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2427959/26785476/db6409cc-4a02-11e7-8a9f-4a82c0d118ce.png)


Mon petit test ('ai pas fait le full build de la box avec cette PR):

```
➜  /vagrant git:(vagrant-cachier) ✗ sudo chown -R vagrant:vagrant /home/vagrant/.config
➜  /vagrant git:(vagrant-cachier) ✗ npm install
➜  /vagrant git:(vagrant-cachier) ✗ sudo chown -R root:root /home/vagrant/.config
➜  /vagrant git:(vagrant-cachier) ✗ npm install                                  

┌───────────────────────────────────────────────────────────┐
│                  npm update check failed                  │
│            Try running with sudo or get access            │
│           to the local update config store via            │
│ sudo chown -R $USER:$(id -gn $USER) /home/vagrant/.config │
└───────────────────────────────────────────────────────────┘
➜  /vagrant git:(vagrant-cachier) ✗ 
```