### PR TITLE
Pin the npm version

### DIFF
--- a/scripts/js.sh
+++ b/scripts/js.sh
@@ -1,5 +1,6 @@
 curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 apt-get -y install nodejs
+export npm_install=4.6.1
 curl -L --insecure https://www.npmjs.org/install.sh | bash
 npm install -g gulp
 chown -R vagrant:vagrant /home/vagrant/.config


### PR DESCRIPTION
npm 5 was recently released, but is not compatible with our old version of nodejs (see the table there https://nodejs.org/en/download/releases/, our current version is 6.10.3)
Their `install.sh` script honors the `npm_install` env var.