### PR TITLE
FIX apt-get

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -9,7 +9,6 @@ rm /var/lib/dhcp/*
 
 # Make sure Udev doesn't block our network
 echo "cleaning up udev rules"
-mkdir /etc/udev/rules.d/70-persistent-net.rules
 rm -rf /dev/.udev/
 rm /lib/udev/rules.d/75-persistent-net-generator.rules
 


### PR DESCRIPTION
After a reboot, when this directory is present, it is not possible to use `apt-get install`